### PR TITLE
Remove download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ For example, Functions\ files should end up in C:\Users\Username\Documents\Majer
 
 ![Screenshot](SampleScreenshot.png)
 
-ActiveScript Shell can be downloaded from http://www.majerus.net/axsh/.
 Version 2.0.8.0 or later is required for dynamic loading of functions to be available.
 
 - Philippe Majerus


### PR DESCRIPTION
Since [**Majerus.net**](http://majerus.net/) domain is empty **_"now"_** (I say **_"now"_** but in reality it's since 2018 I think), users can't download [**Majerus.net ActiveScript Shell**](http://majerus.net/axsh) from the website. Unless you upload latest version somewhere.
Maybe even source code?